### PR TITLE
fix ruby 2.4 warning messages

### DIFF
--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -99,15 +99,15 @@ module PHP
         s << 'N;'
 
       when FalseClass, TrueClass
-        s << "b:#{var ? 1 :0};"
+        s << "b:#{var ? 1 : 0};"
 
       else
         if var.respond_to?(:to_assoc)
           v = var.to_assoc
           # encode as Object with same name
           s << "O:#{var.class.to_s.length}:\"#{var.class.to_s.downcase}\":#{v.length}:{"
-          v.each do |k,v|
-            s << "#{PHP.serialize(k.to_s, assoc)}#{PHP.serialize(v, assoc)}"
+          v.each do |key,value|
+            s << "#{PHP.serialize(key.to_s, assoc)}#{PHP.serialize(value, assoc)}"
           end
           s << '}'
         else
@@ -199,19 +199,19 @@ module PHP
       val
     end
 
-	valid_key_pattern = /^([^!|]+)\|/
-	if string.string =~  valid_key_pattern # session_name|serialized_data
-		ret = Hash.new
-		loop do
-			if string.string[string.pos, 32] =~ valid_key_pattern
-				string.pos += $&.size
-				ret[$1] = PHP.do_unserialize(string, classmap, assoc)
-			else
-				break
-			end
-		end
-		ret
-	else
+    valid_key_pattern = /^([^!|]+)\|/
+    if string.string =~  valid_key_pattern # session_name|serialized_data
+		  ret = Hash.new
+		  loop do
+			  if string.string[string.pos, 32] =~ valid_key_pattern
+				  string.pos += $&.size
+				  ret[$1] = PHP.do_unserialize(string, classmap, assoc)
+			  else
+				  break
+			  end
+		  end
+		  ret
+	  else
       PHP.do_unserialize(string, classmap, assoc)
     end
   end

--- a/test.rb
+++ b/test.rb
@@ -58,9 +58,9 @@ class TestPhpSerialize < Test::Unit::TestCase
   test false, 'b:0;'
   test true, 'b:1;'
   test 42, 'i:42;'
-  test -42, 'i:-42;'
+  test(-42, 'i:-42;')
   test 2147483647, "i:2147483647;", :name => 'Max Fixnum'
-  test -2147483648, "i:-2147483648;", :name => 'Min Fixnum'
+  test(-2147483648, "i:-2147483648;", :name => 'Min Fixnum')
   test 4.2, 'd:4.2;'
   test 'test', 's:4:"test";'
   test 'ümläut_test', 's:13:"ümläut_test";'


### PR DESCRIPTION
fix these warning messages from ruby 2.4

test.rb:61: warning: ambiguous first argument; put parentheses or a space even after `-' operator
test.rb:63: warning: ambiguous first argument; put parentheses or a space even after `-' operator
lib/php_serialize.rb:102: warning: `:' after local variable or literal is interpreted as binary operator
lib/php_serialize.rb:102: warning: even though it seems like symbol literal
lib/php_serialize.rb:109: warning: shadowing outer local variable - v
lib/php_serialize.rb:216: warning: mismatched indentations at 'end' with 'if' at 203